### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,4 +296,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mliu98/awesome-human-distillation&type=Date&t=20260408)](https://star-history.com/#mliu98/awesome-human-distillation&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mliu98/awesome-human-distillation&type=Date&t=20260408)](https://star-history.dera.page/#mliu98/awesome-human-distillation&Date)

--- a/README_EN.md
+++ b/README_EN.md
@@ -133,4 +133,4 @@ Found a Human Distillation Skill? [Open an Issue](https://github.com/mliu98/awes
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mliu98/awesome-human-distillation&type=Date&t=20260408)](https://star-history.com/#mliu98/awesome-human-distillation&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mliu98/awesome-human-distillation&type=Date&t=20260408)](https://star-history.dera.page/#mliu98/awesome-human-distillation&Date)


### PR DESCRIPTION
The star history chart on the README is currently broken because the upstream service can no longer fetch stargazer data under GitHub's API restrictions. This updates the chart links to use a working alternative, star-history.dera.page, so the chart renders correctly again.